### PR TITLE
Updated to work in Sketch 43.2

### DIFF
--- a/Duplicator.sketchplugin/Contents/Sketch/plugin.js
+++ b/Duplicator.sketchplugin/Contents/Sketch/plugin.js
@@ -1,7 +1,6 @@
 
 var DEFAULT_SPACING = 10;
 
-
 function isRetinaDisplay() {
   return NSScreen.isOnRetinaScreen();
 }
@@ -43,7 +42,6 @@ function createAlert(direction,context) {
 
   return alert;
 }
-
 
 function duplicate(direction,showOptionsAlert,context) {
 
@@ -99,11 +97,14 @@ function duplicate(direction,showOptionsAlert,context) {
   for(var n=0;n<repeats;n++) {
 
     var sel=doc.findSelectedLayers();
+    //Deselect all layers in preparation to build new selection for duplication
+    context.document.documentData().deselectAllLayers();
 
     var size=getSelectionSize(sel);
 
     for(var i=0;i<sel.count();i++) {
       var layer=sel.objectAtIndex(i).duplicate();
+      layer.select_byExpandingSelection(true, true); //Add layer to the selection
 
       if(direction=="above") {
         layerOffset(layer,0,-(size.h+spacing));

--- a/Duplicator.sketchplugin/Contents/Sketch/plugin.js
+++ b/Duplicator.sketchplugin/Contents/Sketch/plugin.js
@@ -6,17 +6,6 @@ function isRetinaDisplay() {
   return NSScreen.isOnRetinaScreen();
 }
 
-function actionWithType(type,context) {
-  var doc = context.document;
-
-  var controller = doc.actionsController();
-  if(controller.actionWithName) {
-    return controller.actionWithName(type);
-  } else if(controller.actionWithID) {
-    return controller.actionWithID(type);
-  }
-}
-
 function createAlert(direction,context) {
   var alert = COSAlertWindow.new();
 
@@ -109,15 +98,12 @@ function duplicate(direction,showOptionsAlert,context) {
 
   for(var n=0;n<repeats;n++) {
 
-    var action = actionWithType("MSCanvasActions",context);
-    action.duplicate(null);
-
     var sel=doc.findSelectedLayers();
 
     var size=getSelectionSize(sel);
 
     for(var i=0;i<sel.count();i++) {
-      var layer=sel.objectAtIndex(i);
+      var layer=sel.objectAtIndex(i).duplicate();
 
       if(direction=="above") {
         layerOffset(layer,0,-(size.h+spacing));


### PR DESCRIPTION
Removed the old header references, replaced with layer.duplicate(), deselection and re-selection of copied layers.

I'm not sure if you'll want to keep the backwards compatible header references or not.